### PR TITLE
Run Glint within Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Start from the latest official Rust image to easily compile the project
+FROM rust:alpine as builder
+
+RUN apk update
+
+RUN apk add binutils build-base g++ gcc libressl-dev
+
+# Set the working directory
+WORKDIR /glint
+
+# Copy the current directory content into the container
+COPY . .
+
+# Build the project with release profile to optimize for runtime performance
+RUN cargo build --release
+
+# Create a smaller container for runtime, using Alpine Linux
+FROM alpine as runtime
+
+# Set the working directory for Glint files
+WORKDIR /glint
+
+# Copy the built Glint binary from the builder stage
+COPY --from=builder /glint/target/release/glint /usr/local/bin
+
+# Allow users to provide a configuration directory to mount
+VOLUME /glint
+
+# Define entrypoint to run Glint
+ENTRYPOINT ["/usr/local/bin/glint"]
+
+# Default command to show help if no arguments are provided
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
-<div align="center">
-  <h1><code>glint</code></h1>
-
-  <p><b>A local-only, git-friendly scratchpad for testing API endpoints in your terminal. Define, chain, and automate HTTP requests using simple TOML configuration files.</b></p>
-</div>
-
 > [!WARNING]
 > **This project is in its early stages and may undergo many breaking changes in the future.**
 
-![glint](https://github.com/user-attachments/assets/cc81d961-9a4a-4a0b-8703-6e47cced9762)
+
 
 ## Features
 
@@ -105,3 +99,5 @@ Dependencies tell us how to fill in placeholders. Here's what we support:
    ```
 
 And that's it! You can now use `glint` from your terminal.
+
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
+<div align="center">
+  <h1><code>glint</code></h1>
+
+  <p><b>A local-only, git-friendly scratchpad for testing API endpoints in your terminal. Define, chain, and automate HTTP requests using simple TOML configuration files.</b></p>
+</div>
+
 > [!WARNING]
 > **This project is in its early stages and may undergo many breaking changes in the future.**
 
-
+![glint](https://github.com/user-attachments/assets/cc81d961-9a4a-4a0b-8703-6e47cced9762)
 
 ## Features
 
@@ -123,3 +129,5 @@ Dependencies tell us how to fill in placeholders. Here's what we support:
    ```
 
 And that's it! You can now use `glint` from your terminal or within a Docker container.
+
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ glint examples/github.toml
 
 You can check out some examples in the [examples/](examples/) directory.
 
+### Running with Docker
+
+To run `glint` using Docker, use the following command:
+
+```bash
+docker run --rm -v $(pwd)/examples:/glint johnnyfreeman/glint examples/github.toml
+```
+
+This command mounts your local `examples` directory to the container, allowing Glint to access the example request collections.
+
 ### How It Works
 
 - **Placeholder Resolution:**
@@ -98,6 +108,18 @@ Dependencies tell us how to fill in placeholders. Here's what we support:
    cargo install --path .
    ```
 
-And that's it! You can now use `glint` from your terminal.
+3. **Using Docker:**
 
+   To build the Docker image, use the following command:
 
+   ```bash
+   docker build -t johnnyfreeman/glint .
+   ```
+
+   To run Glint using Docker, use:
+
+   ```bash
+   docker run --rm -v $(pwd)/examples:/glint johnnyfreeman/glint examples/weather.toml
+   ```
+
+And that's it! You can now use `glint` from your terminal or within a Docker container.


### PR DESCRIPTION
This pull request adds support for running Glint inside a Docker container. It introduces a Dockerfile that allows users to easily build and run Glint without needing to install Rust, Git, or other dependencies locally.

**Key Changes:**
- Added a multi-stage Dockerfile for Glint.
  - The builder stage uses the official Rust image to compile Glint with a release profile.
  - The runtime stage uses Alpine Linux to provide a lightweight runtime environment for Glint.
- Added configuration volume support to allow users to mount local configuration files.
- Defined an entrypoint to run Glint directly, making it convenient for users to execute commands.

**Usage Instructions:**
To build the Docker image for Glint, run the following command:
```sh
docker build -t glint .
```

To run Glint within Docker:
```sh
docker run --rm -v /path/to/your/config:/glint glint [OPTIONS] <COLLECTION> [REQUEST]
```
This allows users to run Glint without installing Rust or other dependencies, simplifying the usage for those who prefer containerized tools.

**Why this is useful:**
- Simplifies setup for users who do not wish to install Rust or manage dependencies manually.
- Provides a consistent environment for running Glint, reducing compatibility issues.

**Todos:**

- [x] dockerfile
- [x] docs
- [ ] (optional) github action to build/push image to container registry

