### PR TITLE
Output Customization Flags

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -7,11 +7,17 @@ pub struct Options {
 
     pub request: Option<String>,
 
-    #[arg(long, default_value_t = false)]
+    #[arg(short('h'), long, default_value_t = false)]
     pub show_headers: bool,
+
+    #[arg(short('s'), long, default_value_t = false)]
+    pub hide_status: bool,
+
+    #[arg(short('b'), long, default_value_t = false)]
+    pub hide_body: bool,
+
+    #[arg(short('r'), long, default_value_t = false)]
+    pub raw_output: bool,
     // #[arg(short, long, value_name = "FILE")]
     // pub env: Option<String>,
-
-    // #[arg(short, long, action = clap::ArgAction::Count)]
-    // pub debug: u8,
 }


### PR DESCRIPTION
This PR introduces three new flags to Glint for customizing the output of HTTP responses. These flags provide users with more control over how responses are displayed during their API testing and debugging workflows.

#### Changes

- **`--hide-status (-s)`**:  
  Suppresses the display of the HTTP response status, which is shown by default. Useful when the status code is not relevant to the current workflow.

- **`--hide-body (-b)`**:  
  Suppresses the display of the HTTP response body, which is shown by default. Helps reduce clutter when only headers or status codes are needed.

- **`--raw-output (-r)`**:  
  Disables pretty-printing for response output, showing raw data as received. Ideal for users who prefer minimal or unformatted output for parsing or further processing.

#### Examples

```bash
# Example: Hide status and pretty-print body
glint -s my-collection.toml

# Example: Hide body only
glint -b my-collection.toml my-request

# Example: Display raw response without formatting
glint -r my-collection.toml

# Example: Combine flags
glint -sbr my-collection.toml my-request
```

#### Additional Notes

- The default behavior remains unchanged unless these flags are explicitly provided.
- Flags can be combined to customize output further, enhancing user flexibility.
